### PR TITLE
refactor: 이미지 분석 API를 URL 방식으로 변경

### DIFF
--- a/src/constants/errorCodes.js
+++ b/src/constants/errorCodes.js
@@ -17,5 +17,7 @@ export const ERROR_MESSAGE = {
   TOKEN_EXPIRED: "토큰이 만료되었습니다.",
   USER_NOT_FOUND: "사용자를 찾을 수 없습니다.",
   IMAGE_REQUIRED: "이미지 파일이 필요합니다.",
+  IMAGE_URL_REQUIRED: "이미지 URL이 필요합니다.",
+  IMAGE_FETCH_FAILED: "이미지를 가져올 수 없습니다.",
   FILE_SIZE_EXCEEDED: "파일 크기가 너무 큽니다. (최대 5MB)",
 };

--- a/src/controllers/analysisController.js
+++ b/src/controllers/analysisController.js
@@ -3,18 +3,17 @@ import { analyze } from "../services/analysisService.js";
 
 const createAnalysis = async (req, res, next) => {
   try {
-    const file = req.file;
-    const { url } = req.body;
+    const { imageUrl, pageUrl } = req.body;
     const userId = req.userId;
 
-    if (!file) {
+    if (!imageUrl) {
       return res.status(HTTP_STATUS.BAD_REQUEST).json({
         success: false,
-        error: ERROR_MESSAGE.IMAGE_REQUIRED,
+        error: ERROR_MESSAGE.IMAGE_URL_REQUIRED,
       });
     }
 
-    const analysisResult = await analyze({ file, url, userId });
+    const analysisResult = await analyze({ imageUrl, pageUrl, userId });
 
     res.json({
       success: true,

--- a/src/routes/analysisRoutes.js
+++ b/src/routes/analysisRoutes.js
@@ -2,10 +2,9 @@ import express from "express";
 
 import { createAnalysis } from "../controllers/analysisController.js";
 import { checkToken } from "../middlewares/auth.js";
-import { handleUploadError, upload } from "../middlewares/upload.js";
 
 const router = express.Router();
 
-router.post("/", [upload.single("image"), handleUploadError, checkToken], createAnalysis);
+router.post("/", checkToken, createAnalysis);
 
 export default router;

--- a/src/services/analysisService.js
+++ b/src/services/analysisService.js
@@ -1,12 +1,12 @@
 import env from "../config/env.js";
 import { openai } from "../config/openai.js";
 import { ANALYSIS_SYSTEM_PROMPT } from "../constants/analysisPrompts.js";
-import { fileToDataUrl } from "../utils/imageUtils.js";
+import { urlToDataUrl } from "../utils/imageUtils.js";
 import { parseJsonResponse } from "../utils/jsonUtils.js";
 import { saveHistory } from "./historyService.js";
 
-const analyze = async ({ file, url, userId }) => {
-  const imageDataUrl = fileToDataUrl(file);
+const analyze = async ({ imageUrl, pageUrl, userId }) => {
+  const imageDataUrl = await urlToDataUrl(imageUrl);
   const response = await openai.chat.completions.create({
     model: env.OPENAI_MODEL,
     response_format: { type: "json_object" },
@@ -30,7 +30,7 @@ const analyze = async ({ file, url, userId }) => {
 
   const historyId = await saveHistory({
     userId,
-    url,
+    url: pageUrl,
     title: parsedAnalysis.title,
     summary: parsedAnalysis.summary,
     contentType: "analysis",

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -1,4 +1,29 @@
-export const fileToDataUrl = (file) => {
+import { UPLOAD } from "../constants/common.js";
+import { ERROR_MESSAGE } from "../constants/errorCodes.js";
+
+const fileToDataUrl = (file) => {
   const base64 = file.buffer.toString("base64");
+
   return `data:${file.mimetype};base64,${base64}`;
 };
+
+const urlToDataUrl = async (imageUrl) => {
+  const response = await fetch(imageUrl);
+
+  if (!response.ok) {
+    throw new Error(`${ERROR_MESSAGE.IMAGE_FETCH_FAILED}: ${response.status}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+
+  if (buffer.byteLength > UPLOAD.MAX_FILE_SIZE) {
+    throw new Error(ERROR_MESSAGE.FILE_SIZE_EXCEEDED);
+  }
+
+  const base64 = Buffer.from(buffer).toString("base64");
+  const contentType = response.headers.get("content-type") || "image/png";
+
+  return `data:${contentType};base64,${base64}`;
+};
+
+export { fileToDataUrl, urlToDataUrl };


### PR DESCRIPTION
## 변경 내용
> #13 
- [x]  multer 미들웨어 제거
- [x] imageUrl, pageUrl을 JSON body로 받도록 변경
- [x] urlToDataUrl
- [x] 유틸 함수 추가 외부 이미지 URL fetch → Data URL 변환
- [x] IMAGE_URL_REQUIRED 에러 메시지 추가

## 기타 참고 사항
- 이미지 파일 업로드 방식에서 URL 수신 방식으로 변경했습니다.
- 백엔드에서 imageUrl을 받아 직접 이미지를 fetch합니다.

### 최종 흐름
1. 프론트엔드에서`imageUrl`을 백엔드에 전송
2. 백엔드가 해당 URL에서 이미지를 fetch
3. base64 Data URL로 변환
4. OpenAI API 호출
5. 분석 결과 반환
6. 프론트로 응답 및 회원이면 데이터베이스에 저장, 비회원은 저장 x
