### PR TITLE
release: v1.1.0 프로덕션 배포

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,14 @@ export default [
       "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
     },
   },
+  {
+    files: ["src/utils/puppeteerUtils.js"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+      },
+    },
+  },
   pluginJs.configs.recommended,
   eslintConfigPrettier,
 ];

--- a/src/constants/common.js
+++ b/src/constants/common.js
@@ -34,3 +34,7 @@ export const PAGINATION = {
   DEFAULT_PAGE: 1,
   DEFAULT_LIMIT: 11,
 };
+
+export const ARTICLE_TEXT = {
+  MAX_LENGTH: 2000,
+};

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -8,15 +8,13 @@ import { isArticleUrl } from "../utils/urlUtils.js";
 import { saveHistory } from "./historyService.js";
 
 const summarize = async ({ url, userId, settings }) => {
-  let imageDataUrl,
-    pageText = null;
-  if (isArticleUrl(url)) {
-    ({ imageDataUrl, pageText } = await capturePageWithText(url));
-  } else {
-    imageDataUrl = await captureFullPage(url);
-  }
+  const {
+    imageDataUrl,
+    pageTitle,
+    pageText = null,
+  } = await (isArticleUrl(url) ? capturePageWithText(url) : captureFullPage(url));
 
-  const systemPrompt = getSummaryPrompt(settings, pageText);
+  const systemPrompt = getSummaryPrompt(settings, pageText, pageTitle);
 
   const userContent = [{ type: "image_url", image_url: { url: imageDataUrl } }];
   if (pageText) {

--- a/src/services/summaryService.js
+++ b/src/services/summaryService.js
@@ -3,22 +3,32 @@ import logger from "../config/logger.js";
 import { openai } from "../config/openai.js";
 import { parseJsonResponse } from "../utils/jsonUtils.js";
 import { getSummaryPrompt } from "../utils/promptUtils.js";
-import { captureFullPage } from "../utils/puppeteerUtils.js";
+import { captureFullPage, capturePageWithText } from "../utils/puppeteerUtils.js";
+import { isArticleUrl } from "../utils/urlUtils.js";
 import { saveHistory } from "./historyService.js";
 
 const summarize = async ({ url, userId, settings }) => {
-  const imageDataUrl = await captureFullPage(url);
-  const systemPrompt = getSummaryPrompt(settings);
+  let imageDataUrl,
+    pageText = null;
+  if (isArticleUrl(url)) {
+    ({ imageDataUrl, pageText } = await capturePageWithText(url));
+  } else {
+    imageDataUrl = await captureFullPage(url);
+  }
+
+  const systemPrompt = getSummaryPrompt(settings, pageText);
+
+  const userContent = [{ type: "image_url", image_url: { url: imageDataUrl } }];
+  if (pageText) {
+    userContent.push({ type: "text", text: `[페이지 본문 텍스트]\n${pageText}` });
+  }
 
   const response = await openai.chat.completions.create({
     model: env.OPENAI_MODEL,
     response_format: { type: "json_object" },
     messages: [
       { role: "system", content: systemPrompt },
-      {
-        role: "user",
-        content: [{ type: "image_url", image_url: { url: imageDataUrl } }],
-      },
+      { role: "user", content: userContent },
     ],
   });
 

--- a/src/services/summaryService.test.js
+++ b/src/services/summaryService.test.js
@@ -4,7 +4,7 @@ import logger from "../config/logger.js";
 import { openai } from "../config/openai.js";
 import { parseJsonResponse } from "../utils/jsonUtils.js";
 import { getSummaryPrompt } from "../utils/promptUtils.js";
-import { captureFullPage } from "../utils/puppeteerUtils.js";
+import { captureFullPage, capturePageWithText } from "../utils/puppeteerUtils.js";
 import { saveHistory } from "./historyService.js";
 import { summarize } from "./summaryService.js";
 
@@ -28,6 +28,7 @@ vi.mock("../config/openai.js", () => ({
 
 vi.mock("../utils/puppeteerUtils.js", () => ({
   captureFullPage: vi.fn(),
+  capturePageWithText: vi.fn(),
 }));
 
 vi.mock("../utils/jsonUtils.js", () => ({
@@ -68,7 +69,7 @@ describe("summaryService", () => {
       });
 
       expect(captureFullPage).toHaveBeenCalledWith("https://example.com");
-      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS);
+      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, null);
       expect(openai.chat.completions.create).toHaveBeenCalledWith({
         model: "gpt-4o",
         response_format: { type: "json_object" },
@@ -127,6 +128,41 @@ describe("summaryService", () => {
         summary: "테스트 요약",
         historyId: "history-1",
       });
+    });
+
+    it("기사 URL이면 capturePageWithText를 사용하고 pageText를 프롬프트에 전달한다", async () => {
+      const mockPageText = "기사 본문 내용";
+      capturePageWithText.mockResolvedValue({
+        imageDataUrl: "data:image/png;base64,abc",
+        pageText: mockPageText,
+      });
+      getSummaryPrompt.mockReturnValue("system prompt");
+      openai.chat.completions.create.mockResolvedValue({
+        choices: [{ message: { content: MOCK_JSON } }],
+      });
+      parseJsonResponse.mockReturnValue(MOCK_PARSED);
+
+      await summarize({
+        url: "https://example.com/news/123",
+        userId: null,
+        settings: MOCK_SETTINGS,
+      });
+
+      expect(capturePageWithText).toHaveBeenCalledWith("https://example.com/news/123");
+      expect(captureFullPage).not.toHaveBeenCalled();
+      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, mockPageText);
+      expect(openai.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: "user",
+              content: expect.arrayContaining([
+                { type: "text", text: `[페이지 본문 텍스트]\n${mockPageText}` },
+              ]),
+            }),
+          ]),
+        }),
+      );
     });
 
     it("페이지 캡처 실패 시 요약을 중단하고 에러를 호출자에게 전파한다", async () => {

--- a/src/services/summaryService.test.js
+++ b/src/services/summaryService.test.js
@@ -48,7 +48,10 @@ const MOCK_PARSED = { title: "테스트 제목", summary: "테스트 요약" };
 const MOCK_JSON = JSON.stringify(MOCK_PARSED);
 
 const setupMocks = () => {
-  captureFullPage.mockResolvedValue("data:image/png;base64,abc");
+  captureFullPage.mockResolvedValue({
+    imageDataUrl: "data:image/png;base64,abc",
+    pageTitle: "테스트 페이지",
+  });
   getSummaryPrompt.mockReturnValue("system prompt");
   openai.chat.completions.create.mockResolvedValue({
     choices: [{ message: { content: MOCK_JSON } }],
@@ -69,7 +72,7 @@ describe("summaryService", () => {
       });
 
       expect(captureFullPage).toHaveBeenCalledWith("https://example.com");
-      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, null);
+      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, null, "테스트 페이지");
       expect(openai.chat.completions.create).toHaveBeenCalledWith({
         model: "gpt-4o",
         response_format: { type: "json_object" },
@@ -134,6 +137,7 @@ describe("summaryService", () => {
       const mockPageText = "기사 본문 내용";
       capturePageWithText.mockResolvedValue({
         imageDataUrl: "data:image/png;base64,abc",
+        pageTitle: "기사 사이트",
         pageText: mockPageText,
       });
       getSummaryPrompt.mockReturnValue("system prompt");
@@ -150,7 +154,7 @@ describe("summaryService", () => {
 
       expect(capturePageWithText).toHaveBeenCalledWith("https://example.com/news/123");
       expect(captureFullPage).not.toHaveBeenCalled();
-      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, mockPageText);
+      expect(getSummaryPrompt).toHaveBeenCalledWith(MOCK_SETTINGS, mockPageText, "기사 사이트");
       expect(openai.chat.completions.create).toHaveBeenCalledWith(
         expect.objectContaining({
           messages: expect.arrayContaining([
@@ -174,7 +178,10 @@ describe("summaryService", () => {
     });
 
     it("OpenAI API 호출 실패 시 요약을 중단하고 에러를 호출자에게 전파한다", async () => {
-      captureFullPage.mockResolvedValue("data:image/png;base64,abc");
+      captureFullPage.mockResolvedValue({
+        imageDataUrl: "data:image/png;base64,abc",
+        pageTitle: "테스트 페이지",
+      });
       getSummaryPrompt.mockReturnValue("system prompt");
       openai.chat.completions.create.mockRejectedValue(new Error("OpenAI 서버 에러"));
 

--- a/src/utils/imageUtils.js
+++ b/src/utils/imageUtils.js
@@ -4,7 +4,7 @@ import { UPLOAD } from "../constants/common.js";
 import { AppError } from "../errors/AppError.js";
 import { assertExternalUrl } from "./urlUtils.js";
 
-const urlToDataUrl = async (imageUrl) => {
+export const urlToDataUrl = async (imageUrl) => {
   assertExternalUrl(imageUrl);
   const response = await fetch(imageUrl);
 
@@ -40,5 +40,3 @@ const urlToDataUrl = async (imageUrl) => {
 
   return `data:${contentType || "image/png"};base64,${base64}`;
 };
-
-export { urlToDataUrl };

--- a/src/utils/ipUtils.js
+++ b/src/utils/ipUtils.js
@@ -1,4 +1,4 @@
-const getClientIP = (req) => {
+export const getClientIP = (req) => {
   const forwardedFor = req.headers["x-forwarded-for"];
 
   if (forwardedFor) {
@@ -7,5 +7,3 @@ const getClientIP = (req) => {
 
   return req.ip || null;
 };
-
-export { getClientIP };

--- a/src/utils/promptUtils.js
+++ b/src/utils/promptUtils.js
@@ -1,22 +1,57 @@
 import { LENGTH_INSTRUCTIONS, PERSONA_INSTRUCTIONS } from "../constants/promptConfig.js";
 
-export const getSummaryPrompt = (settings) => {
+export const getSummaryPrompt = (settings, pageText = null) => {
   const lengthInstruction = LENGTH_INSTRUCTIONS[settings.length];
   const personaInstruction = PERSONA_INSTRUCTIONS[settings.persona];
 
+  const textPrinciple = pageText
+    ? `- 스크린샷으로 페이지 전체 구조를 파악하세요.
+- 제공된 본문 텍스트를 기반으로 전체 내용을 요약하세요.
+- 본문 텍스트에 없는 내용은 절대 추측하거나 만들어내지 마세요.`
+    : `- 반드시 스크린샷에서 실제로 보이는 텍스트와 요소만을 근거로 설명하세요.
+- 보이지 않거나 읽을 수 없는 내용은 절대 추측하거나 만들어내지 마세요.
+- 확인할 수 없는 내용은 생략하거나 "확인 불가"로 표현하세요.`;
+
+  const summaryInstruction = pageText
+    ? `[summary 작성 방법]
+- 헤더(##)나 섹션 구분 없이 하나의 단락으로 작성하세요.
+- 첫 문장: 스크린샷을 기반으로 페이지 구조를 위치(상단, 하단, 중앙, 좌측, 우측 등)를 기준으로 자연스럽게 한 문장으로 설명합니다. 중요하지 않은 영역은 생략하세요.
+- 이후: 제공된 본문 텍스트를 기반으로 내용을 요약합니다. ${lengthInstruction}`
+    : `[summary 작성 방법]
+- 페이지 전체 구조와 무엇에 관한 페이지인지 설명합니다. ${lengthInstruction}`;
+
+  const analysisInstruction = pageText
+    ? `[분석 기준]
+- 스크린샷으로 페이지 전체의 구조를 위치 기준(상단, 하단, 중앙, 좌측, 우측 등)으로 파악합니다. 중요하지 않은 영역은 생략해도 됩니다.`
+    : `[분석 기준]
+- 페이지 전체의 구조를 위치 기준(상단, 하단, 중앙, 좌측, 우측 등)으로 파악합니다.`;
+
   return `당신은 시각 장애인을 위해 웹페이지 스크린샷을 분석하는 보조자입니다.
+
+[핵심 원칙]
+${textPrinciple}
 
 [역할]
 - 웹페이지 스크린샷을 보고 페이지의 전체 구조와 주요 내용을 설명합니다.
 - 시각 장애인이 페이지를 이해할 수 있도록 설명합니다.
-- ${lengthInstruction}
 - ${personaInstruction}
+
+${analysisInstruction}
+
+${summaryInstruction}
 
 [출력 형식]
 반드시 한국어로 아래 JSON 형식으로 응답하세요:
-{
-  "title": "페이지의 핵심 주제를 한 줄로 요약",
-  "summary": "페이지 구조와 주요 내용 설명. 어떤 요소들이 있는지, 무엇에 관한 페이지인지 포함."
+${
+  pageText
+    ? `{
+  "title": "콘텐츠 타입에 따라 'XX에 관한 뉴스 기사' 또는 'XX에 관한 블로그 글' 형식으로 작성. XX는 스크린샷과 본문 텍스트에서 파악한 핵심 주제",
+  "summary": "(페이지 구조 한 문장). (본문 내용 요약)"
+}`
+    : `{
+  "title": "스크린샷에서 확인된 페이지 제목 또는 핵심 주제",
+  "summary": "페이지 구조 설명."
+}`
 }`;
 };
 

--- a/src/utils/promptUtils.js
+++ b/src/utils/promptUtils.js
@@ -1,57 +1,53 @@
 import { LENGTH_INSTRUCTIONS, PERSONA_INSTRUCTIONS } from "../constants/promptConfig.js";
 
-export const getSummaryPrompt = (settings, pageText = null) => {
+export const getSummaryPrompt = (settings, pageText = null, pageTitle = null) => {
   const lengthInstruction = LENGTH_INSTRUCTIONS[settings.length];
   const personaInstruction = PERSONA_INSTRUCTIONS[settings.persona];
+  const pageTitleSection = pageTitle
+    ? `[페이지 참고 정보]\n브라우저 탭 제목: ${pageTitle}\n\n`
+    : "";
 
-  const textPrinciple = pageText
-    ? `- 스크린샷으로 페이지 전체 구조를 파악하세요.
-- 제공된 본문 텍스트를 기반으로 전체 내용을 요약하세요.
-- 본문 텍스트에 없는 내용은 절대 추측하거나 만들어내지 마세요.`
-    : `- 반드시 스크린샷에서 실제로 보이는 텍스트와 요소만을 근거로 설명하세요.
-- 보이지 않거나 읽을 수 없는 내용은 절대 추측하거나 만들어내지 마세요.
-- 확인할 수 없는 내용은 생략하거나 "확인 불가"로 표현하세요.`;
+  if (!pageText) {
+    return `당신은 시각 장애인을 위해 웹페이지 스크린샷을 분석하는 보조자입니다.
 
-  const summaryInstruction = pageText
-    ? `[summary 작성 방법]
-- 헤더(##)나 섹션 구분 없이 하나의 단락으로 작성하세요.
-- 첫 문장: 스크린샷을 기반으로 페이지 구조를 위치(상단, 하단, 중앙, 좌측, 우측 등)를 기준으로 자연스럽게 한 문장으로 설명합니다. 중요하지 않은 영역은 생략하세요.
-- 이후: 제공된 본문 텍스트를 기반으로 내용을 요약합니다. ${lengthInstruction}`
-    : `[summary 작성 방법]
-- 페이지 전체 구조와 무엇에 관한 페이지인지 설명합니다. ${lengthInstruction}`;
+${pageTitleSection}[역할]
+- 웹페이지 스크린샷을 보고 페이지의 전체 구조와 주요 내용을 설명합니다.
+- 시각 장애인이 페이지를 이해할 수 있도록 설명합니다.
+- ${lengthInstruction}
+- ${personaInstruction}
 
-  const analysisInstruction = pageText
-    ? `[분석 기준]
-- 스크린샷으로 페이지 전체의 구조를 위치 기준(상단, 하단, 중앙, 좌측, 우측 등)으로 파악합니다. 중요하지 않은 영역은 생략해도 됩니다.`
-    : `[분석 기준]
-- 페이지 전체의 구조를 위치 기준(상단, 하단, 중앙, 좌측, 우측 등)으로 파악합니다.`;
+[출력 형식]
+반드시 한국어로 아래 JSON 형식으로 응답하세요:
+{
+  "title": "페이지의 핵심 주제를 한 줄로 요약. 브라우저 탭 제목이 제공된 경우 이를 활용하세요.",
+  "summary": "페이지 구조와 주요 내용 설명. 어떤 요소들이 있는지, 무엇에 관한 페이지인지 포함."
+}`;
+  }
 
   return `당신은 시각 장애인을 위해 웹페이지 스크린샷을 분석하는 보조자입니다.
 
-[핵심 원칙]
-${textPrinciple}
+${pageTitleSection}[핵심 원칙]
+- 스크린샷으로 페이지 전체 구조를 파악하세요.
+- 제공된 본문 텍스트를 기반으로 전체 내용을 요약하세요.
+- 본문 텍스트에 없는 내용은 절대 추측하거나 만들어내지 마세요.
 
 [역할]
 - 웹페이지 스크린샷을 보고 페이지의 전체 구조와 주요 내용을 설명합니다.
 - 시각 장애인이 페이지를 이해할 수 있도록 설명합니다.
 - ${personaInstruction}
 
-${analysisInstruction}
+[분석 기준]
+- 스크린샷으로 페이지 전체의 구조를 위치 기준(상단, 하단, 중앙, 좌측, 우측 등)으로 파악합니다. 중요하지 않은 영역은 생략해도 됩니다.
 
-${summaryInstruction}
+[summary 작성 방법]
+- 헤더(##)나 섹션 구분 없이 하나의 단락으로 작성하세요.
+- ${lengthInstruction} 첫 문장은 스크린샷 기반 페이지 구조 설명, 나머지는 본문 텍스트 기반 내용 요약으로 구성합니다. 중요하지 않은 영역은 생략하세요.
 
 [출력 형식]
 반드시 한국어로 아래 JSON 형식으로 응답하세요:
-${
-  pageText
-    ? `{
+{
   "title": "콘텐츠 타입에 따라 'XX에 관한 뉴스 기사' 또는 'XX에 관한 블로그 글' 형식으로 작성. XX는 스크린샷과 본문 텍스트에서 파악한 핵심 주제",
   "summary": "(페이지 구조 한 문장). (본문 내용 요약)"
-}`
-    : `{
-  "title": "스크린샷에서 확인된 페이지 제목 또는 핵심 주제",
-  "summary": "페이지 구조 설명."
-}`
 }`;
 };
 

--- a/src/utils/promptUtils.test.js
+++ b/src/utils/promptUtils.test.js
@@ -26,10 +26,11 @@ describe("promptUtils", () => {
       expect(prompt).toContain(LENGTH_INSTRUCTIONS.short);
     });
 
-    it("pageText가 없으면 스크린샷 기반 지시를 포함한다", () => {
+    it("pageText가 없으면 이전 방식의 기본 프롬프트를 사용한다", () => {
       const prompt = getSummaryPrompt({ length: "short", persona: "default" });
 
-      expect(prompt).toContain("스크린샷에서 실제로 보이는 텍스트와 요소만을 근거로");
+      expect(prompt).toContain("페이지 구조와 주요 내용 설명");
+      expect(prompt).toContain(LENGTH_INSTRUCTIONS.short);
     });
   });
 

--- a/src/utils/promptUtils.test.js
+++ b/src/utils/promptUtils.test.js
@@ -18,6 +18,19 @@ describe("promptUtils", () => {
       expect(prompt).toContain('"title"');
       expect(prompt).toContain('"summary"');
     });
+
+    it("pageText가 있으면 본문 텍스트 기반 지시를 포함한다", () => {
+      const prompt = getSummaryPrompt({ length: "short", persona: "default" }, "기사 본문");
+
+      expect(prompt).toContain("제공된 본문 텍스트를 기반으로");
+      expect(prompt).toContain(LENGTH_INSTRUCTIONS.short);
+    });
+
+    it("pageText가 없으면 스크린샷 기반 지시를 포함한다", () => {
+      const prompt = getSummaryPrompt({ length: "short", persona: "default" });
+
+      expect(prompt).toContain("스크린샷에서 실제로 보이는 텍스트와 요소만을 근거로");
+    });
   });
 
   describe("getAnalysisPrompt", () => {

--- a/src/utils/puppeteerUtils.js
+++ b/src/utils/puppeteerUtils.js
@@ -35,19 +35,18 @@ const capturePage = async (url, extractText = false) => {
     });
 
     const imageDataUrl = `data:image/png;base64,${screenshotBuffer.toString("base64")}`;
+    const pageTitle = (await page.title()) || null;
 
-    if (!extractText) return { imageDataUrl };
+    if (!extractText) return { imageDataUrl, pageTitle };
 
     const pageText = await page.evaluate((maxLength) => {
-      /* eslint-disable no-undef */
       ["nav", "header", "footer", "aside", "script", "style"].forEach((tag) =>
-        document.querySelectorAll(tag).forEach((el) => el.remove()),
+        globalThis.document.querySelectorAll(tag).forEach((element) => element.remove()),
       );
-      return document.body.innerText.trim().slice(0, maxLength);
-      /* eslint-enable no-undef */
+      return globalThis.document.body.innerText.trim().slice(0, maxLength);
     }, ARTICLE_TEXT.MAX_LENGTH);
 
-    return { imageDataUrl, pageText: pageText || null };
+    return { imageDataUrl, pageTitle, pageText: pageText || null };
   } catch (error) {
     if (error.message.includes("net::ERR_NAME_NOT_RESOLVED")) {
       throw new AppError("VALIDATION_URL_INVALID");
@@ -64,8 +63,8 @@ const capturePage = async (url, extractText = false) => {
 };
 
 export const captureFullPage = async (url) => {
-  const { imageDataUrl } = await capturePage(url, false);
-  return imageDataUrl;
+  const { imageDataUrl, pageTitle } = await capturePage(url, false);
+  return { imageDataUrl, pageTitle };
 };
 
 export const capturePageWithText = async (url) => {

--- a/src/utils/puppeteerUtils.js
+++ b/src/utils/puppeteerUtils.js
@@ -41,9 +41,9 @@ const capturePage = async (url, extractText = false) => {
 
     const pageText = await page.evaluate((maxLength) => {
       ["nav", "header", "footer", "aside", "script", "style"].forEach((tag) =>
-        globalThis.document.querySelectorAll(tag).forEach((element) => element.remove()),
+        document.querySelectorAll(tag).forEach((element) => element.remove()),
       );
-      return globalThis.document.body.innerText.trim().slice(0, maxLength);
+      return document.body.innerText.trim().slice(0, maxLength);
     }, ARTICLE_TEXT.MAX_LENGTH);
 
     return { imageDataUrl, pageTitle, pageText: pageText || null };

--- a/src/utils/puppeteerUtils.test.js
+++ b/src/utils/puppeteerUtils.test.js
@@ -8,6 +8,7 @@ const createMockPage = (overrides = {}) => ({
   goto: vi.fn(),
   screenshot: vi.fn(() => Buffer.from("screenshot-data")),
   evaluate: vi.fn(() => "추출된 본문 텍스트"),
+  title: vi.fn(() => "테스트 페이지 제목"),
   ...overrides,
 });
 
@@ -47,7 +48,8 @@ describe("puppeteerUtils", () => {
 
       const result = await captureFullPage("https://example.com");
 
-      expect(result).toMatch(/^data:image\/png;base64,/);
+      expect(result.imageDataUrl).toMatch(/^data:image\/png;base64,/);
+      expect(result.pageTitle).toBe("테스트 페이지 제목");
       expect(mockPage.setViewport).toHaveBeenCalledWith({
         width: PUPPETEER.VIEWPORT_WIDTH,
         height: PUPPETEER.VIEWPORT_HEIGHT,
@@ -131,6 +133,7 @@ describe("puppeteerUtils", () => {
       const result = await capturePageWithText("https://example.com/news/123");
 
       expect(result.imageDataUrl).toMatch(/^data:image\/png;base64,/);
+      expect(result.pageTitle).toBe("테스트 페이지 제목");
       expect(result.pageText).toBe("추출된 본문 텍스트");
     });
 

--- a/src/utils/puppeteerUtils.test.js
+++ b/src/utils/puppeteerUtils.test.js
@@ -1,12 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { PUPPETEER } from "../constants/common.js";
-import { captureFullPage } from "./puppeteerUtils.js";
+import { captureFullPage, capturePageWithText } from "./puppeteerUtils.js";
 
 const createMockPage = (overrides = {}) => ({
   setViewport: vi.fn(),
   goto: vi.fn(),
   screenshot: vi.fn(() => Buffer.from("screenshot-data")),
+  evaluate: vi.fn(() => "추출된 본문 텍스트"),
   ...overrides,
 });
 
@@ -116,6 +117,57 @@ describe("puppeteerUtils", () => {
 
       await expect(captureFullPage("https://example.com")).rejects.toThrow(
         expect.objectContaining({ code: "PUPPETEER_CAPTURE_FAILED" }),
+      );
+      expect(mockBrowser.close).toHaveBeenCalled();
+    });
+  });
+
+  describe("capturePageWithText", () => {
+    it("스크린샷과 본문 텍스트를 함께 반환한다", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      puppeteer.launch.mockResolvedValue(mockBrowser);
+
+      const result = await capturePageWithText("https://example.com/news/123");
+
+      expect(result.imageDataUrl).toMatch(/^data:image\/png;base64,/);
+      expect(result.pageText).toBe("추출된 본문 텍스트");
+    });
+
+    it("waitUntil: load 전략을 사용한다", async () => {
+      const mockPage = createMockPage();
+      const mockBrowser = createMockBrowser(mockPage);
+      puppeteer.launch.mockResolvedValue(mockBrowser);
+
+      await capturePageWithText("https://example.com/news/123");
+
+      expect(mockPage.goto).toHaveBeenCalledWith(
+        "https://example.com/news/123",
+        expect.objectContaining({ waitUntil: "load" }),
+      );
+    });
+
+    it("본문 텍스트가 빈 문자열이면 pageText를 null로 반환한다", async () => {
+      const mockPage = createMockPage({ evaluate: vi.fn(() => "") });
+      const mockBrowser = createMockBrowser(mockPage);
+      puppeteer.launch.mockResolvedValue(mockBrowser);
+
+      const result = await capturePageWithText("https://example.com/news/123");
+
+      expect(result.pageText).toBeNull();
+    });
+
+    it("페이지 로딩 시간 초과 시 PUPPETEER_PAGE_TIMEOUT을 던진다", async () => {
+      const mockPage = createMockPage({
+        goto: vi.fn(() => {
+          throw new Error("Navigation Timeout Exceeded");
+        }),
+      });
+      const mockBrowser = createMockBrowser(mockPage);
+      puppeteer.launch.mockResolvedValue(mockBrowser);
+
+      await expect(capturePageWithText("https://example.com/news/123")).rejects.toThrow(
+        expect.objectContaining({ code: "PUPPETEER_PAGE_TIMEOUT" }),
       );
       expect(mockBrowser.close).toHaveBeenCalled();
     });

--- a/src/utils/rateLimitUtils.js
+++ b/src/utils/rateLimitUtils.js
@@ -1,6 +1,6 @@
 import { RATE_LIMIT } from "../constants/common.js";
 
-const getRateLimitInfo = (req) => {
+export const getRateLimitInfo = (req) => {
   const id = req.userId || req.guestId;
   const prefix = req.userId ? RATE_LIMIT.USER_PREFIX : RATE_LIMIT.GUEST_PREFIX;
   const limit = req.userId ? RATE_LIMIT.USER_LIMIT : RATE_LIMIT.GUEST_LIMIT;
@@ -8,5 +8,3 @@ const getRateLimitInfo = (req) => {
 
   return { id, prefix, limit, key };
 };
-
-export { getRateLimitInfo };

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -1,5 +1,16 @@
 import { AppError } from "../errors/AppError.js";
 
+const ARTICLE_URL_PATTERNS = [
+  /v\.daum\.net\/v\//,
+  /\/article\//,
+  /\/news\//,
+  /\/post\//,
+  /\/entry\//,
+  /\/blog\//,
+];
+
+export const isArticleUrl = (url) => ARTICLE_URL_PATTERNS.some((pattern) => pattern.test(url));
+
 const BLOCKED_PATTERNS = [
   /^127\./,
   /^10\./,

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -9,8 +9,6 @@ const ARTICLE_URL_PATTERNS = [
   /\/blog\//,
 ];
 
-export const isArticleUrl = (url) => ARTICLE_URL_PATTERNS.some((pattern) => pattern.test(url));
-
 const BLOCKED_PATTERNS = [
   /^127\./,
   /^10\./,
@@ -21,6 +19,8 @@ const BLOCKED_PATTERNS = [
 ];
 
 const BLOCKED_HOSTS = ["localhost", "[::1]", "[::ffff:a9fe:a9fe]"];
+
+export const isArticleUrl = (url) => ARTICLE_URL_PATTERNS.some((pattern) => pattern.test(url));
 
 export const assertExternalUrl = (url) => {
   const { hostname } = new URL(url);

--- a/src/utils/urlUtils.test.js
+++ b/src/utils/urlUtils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { assertExternalUrl } from "./urlUtils.js";
+import { assertExternalUrl, isArticleUrl } from "./urlUtils.js";
 
 describe("assertExternalUrl", () => {
   it("외부 URL은 에러를 던지지 않는다", () => {
@@ -46,5 +46,36 @@ describe("assertExternalUrl", () => {
     expect(() => assertExternalUrl("http://[::ffff:169.254.169.254]")).toThrow(
       expect.objectContaining({ code: "VALIDATION_URL_INVALID" }),
     );
+  });
+});
+
+describe("isArticleUrl", () => {
+  it("다음 뉴스 URL을 기사로 판단한다", () => {
+    expect(isArticleUrl("https://v.daum.net/v/abc123")).toBe(true);
+  });
+
+  it("/article/ 경로를 기사로 판단한다", () => {
+    expect(isArticleUrl("https://n.news.naver.com/article/001/0012345678")).toBe(true);
+  });
+
+  it("/news/ 경로를 기사로 판단한다", () => {
+    expect(isArticleUrl("https://example.com/news/123")).toBe(true);
+  });
+
+  it("/post/ 경로를 기사로 판단한다", () => {
+    expect(isArticleUrl("https://example.com/post/my-post")).toBe(true);
+  });
+
+  it("/entry/ 경로(티스토리)를 기사로 판단한다", () => {
+    expect(isArticleUrl("https://myblog.tistory.com/entry/title")).toBe(true);
+  });
+
+  it("/blog/ 경로를 기사로 판단한다", () => {
+    expect(isArticleUrl("https://example.com/blog/post-title")).toBe(true);
+  });
+
+  it("포털 메인은 기사로 판단하지 않는다", () => {
+    expect(isArticleUrl("https://naver.com")).toBe(false);
+    expect(isArticleUrl("https://daum.net")).toBe(false);
   });
 });


### PR DESCRIPTION
## 변경 내용
develop 브랜치의 모든 기능을 main으로 merge하여 v1.1.0 프로덕션 배포를 진행합니다.

### 배포 변경 내용
- [x] URL 패턴 기반 콘텐츠 감지 및 텍스트 추출 유틸리티 추가
- [x] 뉴스/블로그 URL 텍스트 기반 요약 프롬프트 및 서비스 통합
- [x] page.title()로 제목 인식 개선 및 프롬프트 출력 분량 조정
- [x] urlUtils 상수와 함수 선언 순서 정리
- [x] utils 파일 export 방식을 export const 인라인으로 통일
- [x] puppeteerUtils에서 globalThis.document를 document로 변경 (ESLint 구조 개선)

## 기타 참고 사항

### 배포 환경
AWS EC2 (t3.medium) + Cloudflare Proxy (spreadloved.com)
Docker Compose (nginx + backend + redis)
